### PR TITLE
Remove duplicate SQLAlchemy JSON import

### DIFF
--- a/api/models_db.py
+++ b/api/models_db.py
@@ -5,7 +5,6 @@ import uuid
 
 from sqlmodel import SQLModel, Field
 from sqlalchemy import Column, JSON as SAJSON
-from sqlalchemy.types import JSON as SAJSON
 
 class ShoppingItem(SQLModel, table=True):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()), primary_key=True, index=True)


### PR DESCRIPTION
## Summary
- remove redundant `JSON` import from `sqlalchemy.types`

## Testing
- `make test` *(fails: Could not find a version that satisfies the requirement fastapi>=0.111)*

------
https://chatgpt.com/codex/tasks/task_e_68b32a9757c483328bf84c349818527c