### PR TITLE
Add auth settings validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ fullfoodapp/
 ollama pull mxbai-embed-large
 ollama pull jina/jina-embeddings-v2-base-es
 ollama pull llama3.1:8b
+
+```
+
+### 🔐 Variables de entorno
+
+- `SERVICE_ENV`: entorno de ejecución (`dev` por defecto). Para producción usar `prod`.
+- `JWT_SECRET`: secreto para firmar tokens JWT. Debe cambiarse respecto al valor por defecto y es obligatorio fuera de desarrollo.
+- `AUTH_FALLBACK_USER`: usuario alternativo para desarrollo. Se deshabilita automáticamente en producción.
+- `AUTH_DEV_PIN`: PIN de desarrollo requerido en `dev` (debe definirse como variable de entorno) y no debe existir en `prod`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,16 @@
+import os
+import sys
 import pytest
 from fastapi.testclient import TestClient
+
+# Aseguramos que el paquete raíz esté en PYTHONPATH
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+# Necesario para instanciar la configuración en modo desarrollo durante los tests.
+os.environ.setdefault("AUTH_DEV_PIN", "123456")
+
 import api.main as main
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+import pytest
+from pydantic import ValidationError
+
+from api.config import Settings
+
+
+def test_jwt_secret_required_non_dev(monkeypatch):
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.delenv("AUTH_DEV_PIN", raising=False)
+    with pytest.raises(ValidationError):
+        Settings(service_env="prod", _env_file=None)
+
+
+def test_auth_fallback_user_disabled_in_prod(monkeypatch):
+    monkeypatch.delenv("AUTH_DEV_PIN", raising=False)
+    settings = Settings(service_env="prod", jwt_secret="s3cr3t", _env_file=None)
+    assert settings.auth_fallback_user is None
+
+
+def test_auth_dev_pin_required_in_dev(monkeypatch):
+    monkeypatch.delenv("AUTH_DEV_PIN", raising=False)
+    with pytest.raises(ValidationError):
+        Settings(service_env="dev", _env_file=None)
+    settings = Settings(service_env="dev", auth_dev_pin="123456", _env_file=None)
+    assert settings.auth_dev_pin == "123456"
+
+
+def test_auth_dev_pin_disallowed_in_prod(monkeypatch):
+    monkeypatch.delenv("AUTH_DEV_PIN", raising=False)
+    with pytest.raises(ValidationError):
+        Settings(service_env="prod", jwt_secret="s3cr3t", auth_dev_pin="123456", _env_file=None)


### PR DESCRIPTION
## Summary
- validate auth settings for JWT secret, fallback user, and dev PIN
- document required environment variables
- test settings validation

## Testing
- `pytest -k 'not integration'` *(fails: email-validator is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b32a9819c08332ba81d2adcb518c35