### PR TITLE
feat: switch Qdrant access to async client

### DIFF
--- a/api/rag.py
+++ b/api/rag.py
@@ -18,8 +18,8 @@ async def hybrid_retrieve(query: str, top_k_each: int = 5) -> List:
     model_map = {"mxbai": "mxbai-embed-large", "jina": "jina-embeddings-v2-base-es"}
     vec_mxbai = await embed_single(query, model_map["mxbai"])
     vec_jina  = await embed_single(query, model_map["jina"])
-    res_mxbai = await search(query, vec_mxbai, "mxbai", top_k_each)
-    res_jina  = await search(query, vec_jina,  "jina",  top_k_each)
+    res_mxbai = await search({"mxbai": vec_mxbai}, top_k_each)
+    res_jina  = await search({"jina": vec_jina},  top_k_each)
     return rrf_fuse([res_mxbai, res_jina])
 
 def build_context(hits, max_chars: int = 1400) -> str:

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -184,7 +184,7 @@ async def generate_recipe(
         raise HTTPException(500, "Fallo al preparar embeddings de búsqueda (sin vectores válidos).")
 
     # 3) Búsqueda RAG
-    hits = search(query_vectors, top_k=req.top_k)
+    hits = await search(query_vectors, top_k=req.top_k)
 
     # 4) Contexto y fuentes
     context = _format_context(hits)

--- a/api/routes/planner.py
+++ b/api/routes/planner.py
@@ -141,7 +141,7 @@ async def _generate_recipe_neutral(
         raise HTTPException(500, "Fallo preparando embeddings de búsqueda (no hay vectores válidos).")
 
     # 3) Búsqueda RAG
-    hits = search(query_vectors, top_k=top_k)
+    hits = await search(query_vectors, top_k=top_k)
 
     # 4) Prompt desde plantilla y llamada LLM
     context = format_context(hits)

--- a/api/routes/rag.py
+++ b/api/routes/rag.py
@@ -35,7 +35,7 @@ async def rag_ingest(
             md["source_id"] = d.id
         payloads.append(md)
     embs = await embed_dual(texts)
-    upsert_documents(texts, payloads, embs)
+    await upsert_documents(texts, payloads, embs)
     return {"ok": True, "ingested": len(texts)}
 
 @router.post(
@@ -61,8 +61,8 @@ async def rag_search(req: SearchRequest = Body(...), user_id: str = Depends(get_
     if not qvecs:
         raise HTTPException(500, "No se obtuvieron embeddings válidos para la consulta.")
 
-    # 3) Búsqueda en Qdrant (SIN await: función síncrona)
-    hits = search(qvecs, top_k=req.top_k)
+    # 3) Búsqueda en Qdrant
+    hits = await search(qvecs, top_k=req.top_k)
 
     # 4) Normaliza la respuesta
     out = []

--- a/tools/ingest_local.py
+++ b/tools/ingest_local.py
@@ -118,8 +118,8 @@ async def ingest_root(root: Path, recreate: bool):
     # Embeddings multi-modelo (usa settings si no pasas models)
     embs = await embed_dual(texts)
 
-    # Inserción (SIN await: es función síncrona)
-    upsert_documents(texts, payloads, embs)
+    # Inserción
+    await upsert_documents(texts, payloads, embs)
     print(f"Ingeridos {len(texts)} chunks de {len(files)} fichero(s) desde {root}")
 
 def main():


### PR DESCRIPTION
## Summary
- adopt AsyncQdrantClient for vector store interactions
- convert vector operations to async and await in routes

## Testing
- `PYTHONPATH=. pytest -q` *(fails: email-validator is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b32a995f088332b2c49026c958f00a