### PR TITLE
Add middleware and authentication tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,40 @@
+import sys
+import types
+from pathlib import Path
+import importlib.metadata as importlib_metadata
+
 import pytest
+
+# Stub ``email_validator`` and its distribution metadata so that pydantic's
+# ``EmailStr`` can be imported without the optional dependency installed.
+mod = types.ModuleType("email_validator")
+
+
+def _validate_email(email, *args, **kwargs):  # pragma: no cover - simple stub
+    return types.SimpleNamespace(email=email, normalized=email, local_part=email)
+
+
+mod.validate_email = _validate_email
+mod.__version__ = "2.0.0"
+sys.modules.setdefault("email_validator", mod)
+
+_orig_version = importlib_metadata.version
+
+
+def _fake_version(name):  # pragma: no cover - used only in tests
+    if name == "email-validator":
+        return "2.0.0"
+    return _orig_version(name)
+
+
+importlib_metadata.version = _fake_version
+# Ensure project root on path for imports when executing from tests dir
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from fastapi.testclient import TestClient
+
 import api.main as main
 
 @pytest.fixture

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -1,0 +1,35 @@
+import pytest
+from api.config import settings
+
+
+def test_protected_endpoint_requires_token(monkeypatch, client):
+    """Endpoints con dependencia de autenticación deben devolver 401 sin token."""
+    monkeypatch.setattr(settings, "auth_fallback_user", None)
+    resp = client.get("/catalog/products")
+    assert resp.status_code == 401
+
+
+def test_size_limit_middleware(client):
+    """El middleware debe rechazar cuerpos que exceden el límite configurado."""
+    big_body = "x" * (settings.max_body_bytes + 1)
+    resp = client.post("/auth/login", data=big_body, headers={"Content-Type": "text/plain"})
+    assert resp.status_code == 413
+
+
+def test_rate_limit_middleware(client):
+    """Al exceder el número de peticiones por ventana se debe obtener 429."""
+    # Asegura que la pila de middlewares esté construida
+    client.get("/health")
+    from api.middleware.rate_limit import RateLimitMiddleware
+
+    layer = client.app.middleware_stack
+    while not isinstance(layer, RateLimitMiddleware):
+        layer = layer.app
+    layer.limit = layer.burst = 2
+    layer.buckets.clear()
+
+    payload = {"email": "user@example.com", "dev_pin": "000000"}
+    assert client.post("/auth/login", json=payload).status_code == 200
+    assert client.post("/auth/login", json=payload).status_code == 200
+    assert client.post("/auth/login", json=payload).status_code == 429
+


### PR DESCRIPTION
## Summary
- stub email-validator dependency for tests
- cover protected endpoints, request size limit, and rate limit middleware

## Testing
- `pytest -m 'not integration' -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32a9c55308332a8749539a8776d62