### PR TITLE
feat: redis-backed rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ fullfoodapp/
 ollama pull mxbai-embed-large
 ollama pull jina/jina-embeddings-v2-base-es
 ollama pull llama3.1:8b
+```
+
+## 📦 Redis para rate limiting
+
+El middleware de límite de peticiones usa **Redis** como almacenamiento compartido. Configura en tu `.env`:
+
+```bash
+REDIS_URL=redis://localhost:6379/0
+REDIS_PASSWORD=tu_password  # opcional
+```
+

--- a/api/config.py
+++ b/api/config.py
@@ -46,6 +46,10 @@ class Settings(BaseSettings):
     rate_limit_rpm: int = 60
     rate_limit_burst: int = 60
 
+    # Redis (rate limiting)
+    redis_url: Optional[str] = None
+    redis_password: Optional[str] = None
+
     # Size limit
     max_body_bytes: int = 262144  # 256KB
 

--- a/api/rate_limit_store.py
+++ b/api/rate_limit_store.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+from collections import defaultdict, deque
+from typing import Deque, Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    from redis.asyncio import Redis  # type: ignore
+except Exception:  # pragma: no cover
+    Redis = None  # type: ignore
+
+from .config import settings
+
+
+class RateLimitStore:
+    def __init__(self) -> None:
+        self._redis: Optional[Redis] = None
+        self._local: Dict[str, Deque[float]] = defaultdict(deque)
+
+    def _use_redis(self) -> bool:
+        return bool(getattr(settings, "redis_url", None) and Redis is not None)
+
+    def _client(self) -> Redis:
+        assert Redis is not None, "redis package no disponible"
+        assert settings.redis_url, "redis_url no configurado"
+        if self._redis is None:
+            self._redis = Redis.from_url(settings.redis_url, password=settings.redis_password)
+        return self._redis
+
+    async def allow(self, key: str, now: float, window: float, limit: int) -> bool:
+        if self._use_redis():
+            try:
+                client = self._client()
+                rkey = f"rl:{key}"
+                min_score = now - window
+                pipe = client.pipeline()
+                pipe.zremrangebyscore(rkey, 0, min_score)
+                pipe.zcard(rkey)
+                _, count = await pipe.execute()
+                if count >= limit:
+                    return False
+                pipe = client.pipeline()
+                pipe.zadd(rkey, {now: now})
+                pipe.expire(rkey, int(window))
+                await pipe.execute()
+                return True
+            except Exception:
+                pass  # fallback a memoria local
+        q = self._local[key]
+        while q and (now - q[0]) > window:
+            q.popleft()
+        if len(q) >= limit:
+            return False
+        q.append(now)
+        return True
+
+
+store = RateLimitStore()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,3 +11,4 @@ tenacity>=8.5.0
 pytest>=8.2
 PyJWT>=2.9.0
 PyYAML>=6.0.2
+redis>=5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest==8.3.2
 pytest-asyncio==0.23.8
 httpx==0.27.0
 requests==2.32.3
+redis==5.0.0


### PR DESCRIPTION
## Summary
- add shared rate limit store with optional Redis backend
- switch middleware to use shared store
- expose Redis credentials in settings and document usage

## Testing
- `PYTHONPATH=. pytest -q` *(fails: email-validator is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b32a9d96ec8332b84ae58e1eebc007