### PR TITLE
feat: switch LLM to Azure OpenAI

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -19,6 +19,12 @@ class Settings(BaseSettings):
     llm_timeout_s: int = 45
     llm_max_concurrency: int = 3
 
+    # Azure OpenAI
+    azure_openai_endpoint: str = ""
+    azure_openai_api_key: str = ""
+    azure_openai_api_version: str = ""
+    azure_openai_llm_deployment: str = ""
+
     # RAG (Qdrant)
     qdrant_url: str = "http://localhost:6333"
     collection_name: str = "recipes"

--- a/api/llm.py
+++ b/api/llm.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 import asyncio
-import json
 from typing import Any, Dict, Optional
-import httpx
+from openai import AsyncAzureOpenAI, APIError, APIConnectionError
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 
 from .config import settings
 
 # Semáforo global para limitar concurrencia
 _llm_semaphore = asyncio.Semaphore(settings.llm_max_concurrency)
+
+# Cliente global de Azure OpenAI
+_azure_client = AsyncAzureOpenAI(
+    azure_endpoint=settings.azure_openai_endpoint,
+    api_key=settings.azure_openai_api_key,
+    api_version=settings.azure_openai_api_version,
+)
 
 class LLMError(RuntimeError):
     pass
@@ -17,38 +23,39 @@ class LLMError(RuntimeError):
     reraise=True,
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=0.5, min=0.5, max=4),
-    retry=retry_if_exception_type((httpx.TimeoutException, httpx.TransportError, LLMError)),
+    retry=retry_if_exception_type((APIConnectionError, APIError, LLMError)),
 )
-async def _ollama_generate(prompt: str, model: str, temperature: float, max_tokens: int) -> str:
+async def _azure_generate(prompt: str, model: str, temperature: float, max_tokens: int) -> str:
     """
-    Llama a Ollama /api/generate con stream=false y devuelve el campo 'response' (texto).
+    Llama a Azure OpenAI Chat Completions y devuelve el contenido generado.
     """
-    url = f"{settings.ollama_url.rstrip('/')}/api/generate"
-    payload: Dict[str, Any] = {
-        "model": model,
-        "prompt": prompt,
-        "stream": False,
-        "options": {
-            "temperature": temperature,
-            "num_predict": max_tokens
-        }
-    }
-    timeout = settings.llm_timeout_s
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        r = await client.post(url, json=payload)
-        if r.status_code >= 500:
-            raise LLMError(f"Ollama 5xx: {r.status_code}")
-        r.raise_for_status()
-        data = r.json()
-        if not isinstance(data, dict) or "response" not in data:
-            raise LLMError("Respuesta inválida de Ollama")
-        return str(data["response"])
+    try:
+        resp = await _azure_client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+    except APIError as e:
+        status = getattr(e, "status_code", None)
+        if status and status >= 500:
+            raise LLMError(f"Azure OpenAI 5xx: {status}") from e
+        raise
+
+    content = None
+    if getattr(resp, "choices", None):
+        msg = resp.choices[0].message
+        if msg and getattr(msg, "content", None) is not None:
+            content = msg.content
+    if content is None:
+        raise LLMError("Respuesta inválida de Azure OpenAI")
+    return str(content)
 
 async def generate_json(prompt: str, model: Optional[str] = None, temperature: float = 0.2, max_tokens: int = 1024) -> str:
     """
-    Genera texto (esperado JSON) usando Ollama, con límite de concurrencia.
+    Genera texto (esperado JSON) usando Azure OpenAI, con límite de concurrencia.
     """
-    mdl = model or settings.llm_model
+    mdl = model or settings.azure_openai_llm_deployment
     async with _llm_semaphore:
-        text = await _ollama_generate(prompt=prompt, model=mdl, temperature=temperature, max_tokens=max_tokens)
+        text = await _azure_generate(prompt=prompt, model=mdl, temperature=temperature, max_tokens=max_tokens)
         return text

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest-asyncio==0.23.8
 httpx==0.27.0
 requests==2.32.3
 redis==5.0.0
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- replace Ollama client with Azure OpenAI async client
- add Azure OpenAI settings and reuse client with semaphore
- list openai dependency

## Testing
- `pytest -q` *(fails: Not Found for /search; RateLimitMiddleware missing buckets)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ba5d6bc08332a64a14483c01891e