### PR TITLE
Refactor vector dim configuration and cleanup Azure OpenAI settings

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -14,18 +14,13 @@ class Settings(BaseSettings):
     # Azure OpenAI / LLM
     azure_openai_endpoint: str = "http://localhost:11434"
     azure_openai_api_key: str | None = None
+    azure_openai_api_version: str = "2024-02-15-preview"
     azure_openai_deployment_llm: str = "gpt-4o-mini"
     azure_openai_deployment_embeddings: str = "text-embedding-3-small"
     azure_openai_timeout_s: int = 180
 
     llm_timeout_s: int = 45
     llm_max_concurrency: int = 3
-
-    # Azure OpenAI
-    azure_openai_endpoint: str = ""
-    azure_openai_api_key: str = ""
-    azure_openai_api_version: str = "2024-02-15-preview"
-    azure_openai_llm_deployment: str = ""
 
 
     # RAG (Qdrant)
@@ -68,18 +63,19 @@ class Settings(BaseSettings):
 
 
     def parsed_vector_dims(self) -> Dict[str, int]:
-        if not self.azure_openai_embedding_deployment:
-            return {}
-        model = self.azure_openai_embedding_deployment
-        # Dimensiones fijas para los modelos de Azure OpenAI más comunes.
-        if "large" in model:
-            dim = 3072
-        elif "small" in model:
-            dim = 1536
-        else:
-            # Valor por defecto si no podemos inferirlo del nombre.
-            dim = 1536
-        return {model: dim}
+        mapping: Dict[str, int] = {}
+        if not self.vector_dims:
+            return mapping
+        pairs = [p.strip() for p in self.vector_dims.split(",") if p.strip()]
+        for pair in pairs:
+            if ":" not in pair:
+                continue
+            model, dim_str = pair.split(":", 1)
+            try:
+                mapping[model.strip()] = int(dim_str.strip())
+            except ValueError:
+                continue
+        return mapping
 
     def parsed_api_keys(self) -> Dict[str, str]:
         mapping: Dict[str, str] = {}


### PR DESCRIPTION
## Summary
- parse `vector_dims` setting into a mapping of model names to dimensions
- remove duplicate Azure OpenAI configuration fields to avoid confusion

## Testing
- `python - <<'PY'
from api.config import settings
print(settings.vector_dims)
print(settings.parsed_vector_dims())
PY`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `pip install openai email-validator -q` *(fails: Could not find a version that satisfies the requirement openai)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c1879ed483329bd354bda68caa36