### PR TITLE
Parse vector dims from config

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -14,18 +14,13 @@ class Settings(BaseSettings):
     # Azure OpenAI / LLM
     azure_openai_endpoint: str = "http://localhost:11434"
     azure_openai_api_key: str | None = None
+    azure_openai_api_version: str = "2024-02-15-preview"
     azure_openai_deployment_llm: str = "gpt-4o-mini"
     azure_openai_deployment_embeddings: str = "text-embedding-3-small"
     azure_openai_timeout_s: int = 180
 
     llm_timeout_s: int = 45
     llm_max_concurrency: int = 3
-
-    # Azure OpenAI
-    azure_openai_endpoint: str = ""
-    azure_openai_api_key: str = ""
-    azure_openai_api_version: str = "2024-02-15-preview"
-    azure_openai_llm_deployment: str = ""
 
 
     # RAG (Qdrant)
@@ -68,18 +63,16 @@ class Settings(BaseSettings):
 
 
     def parsed_vector_dims(self) -> Dict[str, int]:
-        if not self.azure_openai_embedding_deployment:
-            return {}
-        model = self.azure_openai_embedding_deployment
-        # Dimensiones fijas para los modelos de Azure OpenAI más comunes.
-        if "large" in model:
-            dim = 3072
-        elif "small" in model:
-            dim = 1536
-        else:
-            # Valor por defecto si no podemos inferirlo del nombre.
-            dim = 1536
-        return {model: dim}
+        mapping: Dict[str, int] = {}
+        for pair in [p.strip() for p in self.vector_dims.split(",") if p.strip()]:
+            if ":" not in pair:
+                continue
+            model, dim_str = pair.split(":", 1)
+            try:
+                mapping[model.strip()] = int(dim_str.strip())
+            except ValueError:
+                continue
+        return mapping
 
     def parsed_api_keys(self) -> Dict[str, str]:
         mapping: Dict[str, str] = {}


### PR DESCRIPTION
## Summary
- parse vector_dims setting into model-to-dimension mapping
- streamline Azure OpenAI settings to avoid duplicates

## Testing
- `python - <<'PY'
import types, sys, asyncio
from unittest.mock import AsyncMock, patch
import importlib, importlib.metadata
class DummyAzureClient:
    def __init__(self, *args, **kwargs):
        pass
openai_stub = types.SimpleNamespace(AsyncAzureOpenAI=DummyAzureClient, APIError=Exception, APIConnectionError=Exception)
sys.modules['openai'] = openai_stub
def _validate_email(email, allow_smtputf8=True, allow_empty_local=False):
    return types.SimpleNamespace(email=email)
email_validator_stub = types.SimpleNamespace(validate_email=_validate_email)
sys.modules['email_validator'] = email_validator_stub
class DummyDist:
    version = '2.0.0'

def dummy_distribution(name):
    if name == 'email-validator':
        return DummyDist()
    raise importlib.metadata.PackageNotFoundError(name)

def dummy_version(name):
    if name == 'email-validator':
        return DummyDist().version
    raise importlib.metadata.PackageNotFoundError(name)
importlib.metadata.distribution = dummy_distribution
importlib.metadata.version = dummy_version
import api.main as main
async def run():
    with patch('api.main.ensure_collection', new=AsyncMock()) as mock_ensure:
        await main.startup()
        print('parsed dims in startup:', mock_ensure.call_args[0][0])
asyncio.run(run())
PY`
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b6c187c9088332a7cc48cd2b712335