### PR TITLE
Fix Azure OpenAI health check vars

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -113,7 +113,11 @@ async def health_deep():
     except Exception as e:
         ao_ok, ao_err = False, str(e)
         out["status"] = "degraded"
-    out["checks"]["azure_openai"] = {"ok": o_ok, "latency_ms": round((time.perf_counter()-t1)*1000, 1), "error": o_err}
+    out["checks"]["azure_openai"] = {
+        "ok": ao_ok,
+        "latency_ms": round((time.perf_counter() - t1) * 1000, 1),
+        "error": ao_err,
+    }
 
 
     return out


### PR DESCRIPTION
## Summary
- use consistent ao_ok/ao_err variable names in deep health check
- update azure_openai check dictionary to reference corrected variables

## Testing
- `python -m pyflakes api/main.py` *(fails: No module named pyflakes)*
- `pip install pyflakes` *(fails: could not find a version; proxy 403)*
- `python -m py_compile api/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68b6c18a109c8332a1c23c7521802630